### PR TITLE
add date to ProvidesClass (fix ifnum error)

### DIFF
--- a/TheMartianReport.cls
+++ b/TheMartianReport.cls
@@ -10,7 +10,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{TheMartianReport}[2018 Project Documentation LaTeX class]
+\ProvidesClass{TheMartianReport}[2018/04/26 Project Documentation LaTeX class]
 
 % SET UP PAPER DIMENSIONS
 \LoadClass[10pt, a4paper]{article}


### PR DESCRIPTION
Thank you for this awesome template :+1: ! When I tried building it I got some strange `\ifnum` errors. Turned out this was caused by the date format you used in the `\ProvidesClass` command. This PR fixes that.